### PR TITLE
Update CNI plugins from v0.8.6 to v0.8.7

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 Notable changes between versions
 
+## v0.4.1
+
+* Update CNI plugins from v0.8.6 to v0.8.7 ([#3](https://github.com/poseidon/flannel-cni/pull/3))
+
 ## v0.4.0
 
 * Update CNI plugins from v0.6.0 to v0.8.6

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 VERSION=$(shell git describe --tags --match=v* --always --dirty)
-CNI_VERSION=v0.8.6
+CNI_VERSION=v0.8.7
 
 LOCAL_REPO?=poseidon/flannel-cni
 IMAGE_REPO?=quay.io/poseidon/flannel-cni


### PR DESCRIPTION
* https://github.com/containernetworking/plugins/releases/tag/v0.8.7