### PR TITLE
Update CNI plugins from v0.9.0 to v0.9.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 VERSION=$(shell git describe --tags --match=v* --always --dirty)
-CNI_VERSION=v0.9.0
+CNI_VERSION=v0.9.1
 
 LOCAL_REPO?=poseidon/flannel-cni
 IMAGE_REPO?=quay.io/poseidon/flannel-cni


### PR DESCRIPTION
* https://github.com/containernetworking/plugins/releases/tag/v0.9.1