### PR TITLE
Add a SLEEP environment variable to sleep when complete

### DIFF
--- a/scripts/install-cni.sh
+++ b/scripts/install-cni.sh
@@ -10,6 +10,7 @@ set -eu;
 # Variables:
 # CNI_CONF_NAME - CNI config filename
 # CNI_NETWORK_CONFIG - CNI configuration
+# SLEEP - optionally sleep once done
 
 CNI_BIN_DIR=${CNI_BIN_DIR:-/opt/cni/bin}
 
@@ -36,3 +37,7 @@ else
   echo "Skip writing CNI config"
 fi;
 
+if [ "$SLEEP" == "true" ]; then
+  echo "Sleep mode"
+  while true; do sleep 3600; done;
+fi


### PR DESCRIPTION
* Certain edge cases use flannel-cni as a standalone DaemonSet rather than as an init container, so it is useful to offer
a sleep option. Set the SLEEP env var to "true" to enable