### PR TITLE
Add opencontainers labels to container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,9 @@ RUN /scripts/fetch-cni.sh
 
 FROM docker.io/alpine:3.17.1
 LABEL maintainer="Dalton Hubble <dghubble@gmail.com>"
+LABEL org.opencontainers.image.title="flannel-cni",
+LABEL org.opencontainers.image.source="https://github.com/poseidon/flannel-cni"
+LABEL org.opencontainers.image.vendor="Poseidon Labs"
 COPY --from=builder /bin/flannel /opt/cni/bin/flannel
 COPY --from=builder /bin/loopback /opt/cni/bin/loopback
 COPY --from=builder /bin/bridge /opt/cni/bin/bridge

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-# flannel-cni [![Quay](https://img.shields.io/badge/container-quay-green)](https://quay.io/repository/poseidon/flannel-cni) [![Sponsors](https://img.shields.io/github/sponsors/poseidon?logo=github)](https://github.com/sponsors/poseidon) [![Twitter](https://img.shields.io/badge/follow-news-1da1f2?logo=twitter)](https://twitter.com/typhoon8s)
+# flannel-cni
+[![Quay](https://img.shields.io/badge/container-quay-green)](https://quay.io/repository/poseidon/flannel-cni)
+[![Sponsors](https://img.shields.io/github/sponsors/poseidon?logo=github)](https://github.com/sponsors/poseidon)
+[![Mastodon](https://img.shields.io/badge/follow-news-6364ff?logo=mastodon)](https://fosstodon.org/@poseidon)
 
 `flannel-cni` provides a container image that installs a CNI config and CNI binaries on Kubernetes nodes. Ideal for container-optimized OSes like Fedora CoreOS and Flatcar Linux.
 


### PR DESCRIPTION
* Add opencontainers.org labels to the published container image to support tools that read those labels
* Update README badges to remove Twitter and add Mastodon