### PR TITLE
Update CNI plugins from v0.9.1 to v1.5.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,9 @@ Notable changes between versions
 
 ## Latest
 
+* Update CNI plugins from v0.9.1 to v1.5.1
+* Drop flannel plugin from image since upstream doesn't publish arm64
+
 ## v0.4.2
 
 * Update CNI plugins from v0.8.7 to v0.9.1 ([#4](https://github.com/poseidon/flannel-cni/pull/4), [#5](https://github.com/poseidon/flannel-cni/pull/5))

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,6 @@ LABEL maintainer="Dalton Hubble <dghubble@gmail.com>"
 LABEL org.opencontainers.image.title="flannel-cni",
 LABEL org.opencontainers.image.source="https://github.com/poseidon/flannel-cni"
 LABEL org.opencontainers.image.vendor="Poseidon Labs"
-COPY --from=builder /bin/flannel /opt/cni/bin/flannel
 COPY --from=builder /bin/loopback /opt/cni/bin/loopback
 COPY --from=builder /bin/bridge /opt/cni/bin/bridge
 COPY --from=builder /bin/host-local /opt/cni/bin/host-local

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 VERSION=$(shell git describe --tags --match=v* --always --dirty)
-CNI_VERSION=v0.9.1
+CNI_VERSION=v1.5.1
 
 LOCAL_REPO?=poseidon/flannel-cni
 IMAGE_REPO?=quay.io/poseidon/flannel-cni

--- a/scripts/fetch-cni.sh
+++ b/scripts/fetch-cni.sh
@@ -7,5 +7,5 @@ set -ex
 apk --no-cache add curl
 
 echo "Download CNI plugins ${CNI_VERSION} for ${ARCH}"
-curl -sSfL https://github.com/containernetworking/plugins/releases/download/${CNI_VERSION}/cni-plugins-linux-${ARCH}-${CNI_VERSION}.tgz | tar -xz -C bin/ ./flannel ./loopback ./bridge ./host-local ./portmap ./tuning ./bandwidth
+curl -sSfL https://github.com/containernetworking/plugins/releases/download/${CNI_VERSION}/cni-plugins-linux-${ARCH}-${CNI_VERSION}.tgz | tar -xz -C bin/ ./loopback ./bridge ./host-local ./portmap ./tuning ./bandwidth
 


### PR DESCRIPTION
* Update CNI plugins from v0.9.1 to v1.5.1
* Drop flannel plugin from image since upstream doesn't publish arm64

Related: https://github.com/containernetworking/plugins/releases/tag/v1.0.1